### PR TITLE
Remove duplicate flag --rpc-port

### DIFF
--- a/content/md/en/docs/tutorials/build-a-blockchain/simulate-network.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/simulate-network.md
@@ -74,7 +74,6 @@ To start the blockchain:
    --chain local \
    --alice \
    --port 30333 \
-   --rpc-port 9945 \
    --rpc-port 9933 \
    --node-key 0000000000000000000000000000000000000000000000000000000000000001 \
    --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
@@ -91,7 +90,6 @@ Before moving on, have a look at how the following options are used to start the
 | `--chain local`                                             | Specifies the chain specification to use. Valid predefined chain specifications include `local`, `development`, and `staging`.                                                                                                             |
 | `--alice`                                                   | Adds the predefined keys for the `alice` account to the node's keystore. With this setting, the `alice` account is used for block production and finalization.                                                                             |
 | `--port 30333`                                              | Specifies the port to listen on for peer-to-peer (`p2p`) traffic. Because this tutorial uses two nodes running on the same physical computer to simulate a network, you must explicitly specify a different port for at least one account. |
-| `--rpc-port 9945`                                            | Specifies the port to listen on for incoming WebSocket traffic. The default port is `9944`. This tutorial uses a custom web socket port number (`9945`).                                                                                   |
 | `--rpc-port 9933`                                           | Specifies the port to listen on for incoming RPC traffic. The default port is `9933`.                                                                                                                                                      |
 | `--node-key <key>`                                          | Specifies the Ed25519 secret key to use for `libp2p` networking. You should only use this option for development and testing.                                                                                                              |
 | `--telemetry-url`                                           | Specifies where to send telemetry data. For this tutorial, you can send telemetry data to a server hosted by Parity that is available for anyone to use.                                                                                   |
@@ -169,7 +167,6 @@ To add a node to the running blockchain:
    --chain local \
    --bob \
    --port 30334 \
-   --rpc-port 9946 \
    --rpc-port 9934 \
    --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
    --validator \


### PR DESCRIPTION
This command has `--rpc-port` duplicated, and running it results in ```error: the argument '--rpc-port <PORT>' cannot be used multiple times``` error.  Also since `--ws-port` flag is removed in favour of `--rpc-port` flag, the duplicate flag must be dropped.