### PR TITLE
Remove double --rpc-port CMD argument

### DIFF
--- a/content/md/en/docs/tutorials/build-a-blockchain/add-trusted-nodes.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/add-trusted-nodes.md
@@ -303,7 +303,6 @@ To start the first node:
       --base-path /tmp/node01 \
       --chain ./customSpecRaw.json \
       --port 30333 \
-      --rpc-port 9945 \
       --rpc-port 9933 \
       --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
       --validator \
@@ -473,7 +472,6 @@ To add a second validator to the private network:
       --base-path /tmp/node02 \
       --chain ./customSpecRaw.json \
       --port 30334 \
-      --rpc-port 9946 \
       --rpc-port 9934 \
       --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
       --validator \


### PR DESCRIPTION
Since --ws-port CMD argument has been removed in favour of --rpc-port CMD argument, we are left with double --rpc-port in code snippet.